### PR TITLE
Change preserve-paths to use "sites/all" to protect multisite folders.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,15 +79,7 @@
             }
         },
         "preserve-paths": [
-            "web/sites/all/drush",
-            "web/sites/all/libraries",
-            "web/sites/all/modules/contrib",
-            "web/sites/all/modules/custom",
-            "web/sites/all/modules/features",
-            "web/sites/all/themes/contrib",
-            "web/sites/all/themes/custom",
-            "web/sites/all/translations",
-            "web/sites/default"
+            "web/sites/all"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
             }
         },
         "preserve-paths": [
-            "web/sites/all"
+            "web/sites"
         ]
     }
 }


### PR DESCRIPTION
In the drupal 7 composer template, running `composer install` the first time (or when you delete vender folder) will silently remove any `sites/X` folders. This will destroy any multisites installed, and prevents the codebase from being used with systems like @aegirproject.

Changing the preserve-paths value to "web/sites" worked great for me.

